### PR TITLE
Remove redundant dependencies

### DIFF
--- a/quick-method-evaluate/pom.xml
+++ b/quick-method-evaluate/pom.xml
@@ -12,6 +12,40 @@
             <groupId>com.github.houbb</groupId>
             <artifactId>junitperf</artifactId>
             <version>2.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter-engine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.houbb</groupId>
+                    <artifactId>log-integration</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.freemarker</groupId>
+                    <artifactId>freemarker</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-math3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apiguardian</groupId>
+                    <artifactId>apiguardian-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.opentest4j</groupId>
+                    <artifactId>opentest4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-commons</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
@vector4wang Hi, I am a user of project **_com.quick:quick-method-evaluate:1.0-SNAPSHOT_**. I found that its pom file introduced **_13_** dependencies. However, among them, **_11_** libraries (**_84%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_com.quick:quick-method-evaluate:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
com.github.houbb:paradise-common:jar:1.1.1:compile
org.apache.commons:commons-math3:jar:3.6.1:compile
org.junit.platform:junit-platform-commons:jar:1.2.0:compile
com.google.guava:guava:jar:21.0:compile
org.junit.jupiter:junit-jupiter-api:jar:5.2.0:compile
org.junit.jupiter:junit-jupiter-engine:jar:5.2.0:compile
org.freemarker:freemarker:jar:2.3.23:compile
org.opentest4j:opentest4j:jar:1.1.0:compile
com.github.houbb:log-integration:jar:1.1.3:compile
org.apiguardian:apiguardian-api:jar:1.0.0:compile
org.junit.platform:junit-platform-engine:jar:1.2.0:compile
</code></pre>